### PR TITLE
[codex] Fix WeChat empty conversion caching

### DIFF
--- a/src/__tests__/adapters-behavior.test.ts
+++ b/src/__tests__/adapters-behavior.test.ts
@@ -116,6 +116,27 @@ describe("adapter behavior", () => {
     expect(processed).toContain("plain article");
   });
 
+  it("wechat postProcess promotes js_content into a focused article document", () => {
+    const html = `<html><head><title>Fallback</title></head><body>
+      <h1 id="activity-name">Article Title</h1>
+      <span id="js_name">Author Name</span>
+      <div id="js_content">
+        <p>real article body</p>
+        <img data-src="https://mmbiz.qpic.cn/mmbiz_png/a/640" />
+      </div>
+      <div class="share-widget">outside noise</div>
+    </body></html>`;
+
+    const processed = wechatAdapter.postProcess!(html);
+
+    expect(processed).toContain('data-adapter="wechat"');
+    expect(processed).toContain("<h1>Article Title</h1>");
+    expect(processed).toContain("作者: Author Name");
+    expect(processed).toContain("real article body");
+    expect(processed).toContain('src="https://mmbiz.qpic.cn/mmbiz_png/a/640"');
+    expect(processed).not.toContain("outside noise");
+  });
+
   it("keeps feishu adapter as no-op extraction", async () => {
     expect(feishuAdapter.alwaysBrowser).toBe(true);
     expect(await feishuAdapter.extract({} as any, new Map())).toBeNull();

--- a/src/__tests__/cache-edge.test.ts
+++ b/src/__tests__/cache-edge.test.ts
@@ -74,6 +74,31 @@ describe("cache edge behavior", () => {
     expect(result).toBeNull();
   });
 
+  it("returns null for empty cached content", async () => {
+    const { env, mocks } = createCacheEnv();
+    mocks.kvGet.mockResolvedValueOnce(JSON.stringify({
+      content: "  ",
+      method: "readability+turndown",
+      title: "",
+    }));
+
+    const result = await getCached(env, "https://example.com/empty-cache", "markdown");
+
+    expect(result).toBeNull();
+  });
+
+  it("does not store empty cache content", async () => {
+    const { env, mocks } = createCacheEnv();
+
+    await setCache(env, "https://example.com/empty-write", "markdown", {
+      content: "",
+      method: "readability+turndown",
+      title: "",
+    });
+
+    expect(mocks.kvPut).not.toHaveBeenCalled();
+  });
+
   it("does not use hot cache when ttl is zero", async () => {
     const { env, mocks } = createCacheEnv();
     const url = "https://example.com/no-hot-cache";

--- a/src/__tests__/index-mocked-branches.test.ts
+++ b/src/__tests__/index-mocked-branches.test.ts
@@ -34,6 +34,9 @@ const mocked = vi.hoisted(() => ({
     fetchViaProxy: vi.fn(),
     fetchViaProxyPool: vi.fn(),
   },
+  browserUse: {
+    fetchViaBrowserUse: vi.fn(),
+  },
 }));
 
 vi.mock("cloudflare:sockets", () => ({
@@ -75,6 +78,10 @@ vi.mock("../proxy", () => ({
   parseProxyPool: mocked.proxy.parseProxyPool,
   fetchViaProxy: mocked.proxy.fetchViaProxy,
   fetchViaProxyPool: mocked.proxy.fetchViaProxyPool,
+}));
+
+vi.mock("../browser-use", () => ({
+  fetchViaBrowserUse: mocked.browserUse.fetchViaBrowserUse,
 }));
 
 import worker from "../index";
@@ -145,6 +152,7 @@ beforeEach(() => {
     attempts: 1,
     errors: [],
   });
+  mocked.browserUse.fetchViaBrowserUse.mockResolvedValue(null);
 });
 
 describe("index mocked branch coverage", () => {
@@ -206,6 +214,55 @@ describe("index mocked branch coverage", () => {
     expect(res.status).toBe(502);
     expect(payload.error).toBe("Fetch Failed");
     expect(payload.message).toContain("configure PROXY_URL");
+  });
+
+  it("does not cache empty output when anonymous always-browser fallbacks return no content", async () => {
+    mocked.browser.alwaysNeedsBrowser.mockReturnValue(true);
+    mocked.converter.htmlToMarkdown.mockImplementation((html: string) => ({
+      markdown: html.trim() ? "# md body" : "",
+      title: "",
+      contentHtml: html,
+    }));
+
+    const req = new Request("https://md.example.com/https://example.com/needs-browser?raw=true", {
+      headers: { Accept: "application/json" },
+    });
+    const res = await worker.fetch(req, createMockEnv().env, mockCtx());
+    const payload = await res.json() as { error?: string; message?: string };
+
+    expect(res.status).toBe(502);
+    expect(payload.error).toBe("Fetch Failed");
+    expect(payload.message).toContain("requires browser or proxy access");
+    expect(mocked.cache.setCache).not.toHaveBeenCalled();
+  });
+
+  it("uses static WeChat fetch for anonymous users when remote browser and proxy produce no content", async () => {
+    mocked.browser.alwaysNeedsBrowser.mockReturnValue(true);
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response("<html><body><div id=\"js_content\">wechat article</div></body></html>", {
+        status: 200,
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    mocked.converter.htmlToMarkdown.mockImplementation((html: string) => ({
+      markdown: html.includes("wechat article") ? "# wechat article" : "",
+      title: "wechat",
+      contentHtml: "<article>wechat article</article>",
+    }));
+
+    const req = new Request("https://md.example.com/https://mp.weixin.qq.com/s/abc?raw=true", {
+      headers: { Accept: "text/markdown" },
+    });
+    const res = await worker.fetch(req, createMockEnv().env, mockCtx());
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("proxied:# wechat article");
+    expect(fetchMock).toHaveBeenCalled();
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect((init.headers as Record<string, string>)["User-Agent"]).toContain("MicroMessenger");
+    expect((init.headers as Record<string, string>).Referer).toBe("https://mp.weixin.qq.com/");
+    expect(res.headers.get("X-Markdown-Fallbacks")).toContain("wechat_static_fallback");
   });
 
   it("retries through proxy and succeeds after PROXY_RETRY signal", async () => {

--- a/src/browser/adapters/wechat.ts
+++ b/src/browser/adapters/wechat.ts
@@ -2,6 +2,64 @@ import type { SiteAdapter, ExtractResult } from "../../types";
 import { WECHAT_UA } from "../../config";
 import { STEALTH_SCRIPT } from "../stealth";
 import { createProxyRetrySignal } from "../proxy-retry";
+import { parseHTML } from "linkedom";
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (ch) => {
+    switch (ch) {
+      case "&": return "&amp;";
+      case "<": return "&lt;";
+      case ">": return "&gt;";
+      case '"': return "&quot;";
+      default: return "&#039;";
+    }
+  });
+}
+
+function normalizeText(value: string | null | undefined): string {
+  return (value || "").replace(/\s+/g, " ").trim();
+}
+
+function extractWechatArticleHtml(html: string): string | null {
+  if (!html.includes("js_content")) return null;
+
+  try {
+    const { document } = parseHTML(html);
+    const content = document.querySelector("#js_content") as any;
+    if (!content) return null;
+
+    content.querySelectorAll?.("img[data-src]").forEach((img: any) => {
+      const real = img.getAttribute("data-src");
+      if (real) img.setAttribute("src", real);
+    });
+
+    const title = normalizeText(
+      (document.querySelector("#activity-name") as any)?.textContent ||
+      (document.querySelector("meta[property='og:title']") as any)?.getAttribute?.("content") ||
+      document.title,
+    );
+    const author = normalizeText((document.querySelector("#js_name") as any)?.textContent);
+    const publishTime = normalizeText(
+      (document.querySelector("[data-wechat-meta='publish_time']") as any)?.textContent,
+    );
+
+    const metaParts: string[] = [];
+    if (author) metaParts.push(`<p data-wechat-meta="author">作者: ${escapeHtml(author)}</p>`);
+    if (publishTime) metaParts.push(`<p data-wechat-meta="publish_time">${escapeHtml(publishTime)}</p>`);
+
+    return [
+      "<html><head>",
+      `<title>${escapeHtml(title)}</title>`,
+      "</head><body><article data-adapter=\"wechat\">",
+      title ? `<h1>${escapeHtml(title)}</h1>` : "",
+      ...metaParts,
+      content.outerHTML || content.innerHTML || "",
+      "</article></body></html>",
+    ].join("");
+  } catch {
+    return null;
+  }
+}
 
 export const wechatAdapter: SiteAdapter = {
   match(url: string): boolean {
@@ -97,6 +155,42 @@ export const wechatAdapter: SiteAdapter = {
         });
       })()
     `);
+
+    const articleHtml = await page.evaluate(`
+      (function() {
+        function esc(s) {
+          return String(s || '').replace(/[&<>"']/g, function(ch) {
+            return ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#039;'})[ch];
+          });
+        }
+        function txt(sel) {
+          var el = document.querySelector(sel);
+          return el ? (el.textContent || '').replace(/\\s+/g, ' ').trim() : '';
+        }
+        var content = document.getElementById('js_content');
+        if (!content) return '';
+        content.querySelectorAll('img[data-src]').forEach(function(img) {
+          var real = img.getAttribute('data-src');
+          if (real) img.setAttribute('src', real);
+        });
+        var title = txt('#activity-name') || document.title || '';
+        var author = txt('#js_name');
+        var publish = txt('[data-wechat-meta="publish_time"]');
+        var parts = [
+          '<html><head><title>' + esc(title) + '</title></head><body><article data-adapter="wechat">'
+        ];
+        if (title) parts.push('<h1>' + esc(title) + '</h1>');
+        if (author) parts.push('<p data-wechat-meta="author">作者: ' + esc(author) + '</p>');
+        if (publish) parts.push('<p data-wechat-meta="publish_time">' + esc(publish) + '</p>');
+        parts.push(content.outerHTML || content.innerHTML || '');
+        parts.push('</article></body></html>');
+        return parts.join('');
+      })()
+    `);
+    if (articleHtml && articleHtml.length > 200) {
+      return { html: articleHtml };
+    }
+
     const html = await page.content();
     return { html };
   },
@@ -150,6 +244,6 @@ export const wechatAdapter: SiteAdapter = {
       },
     );
 
-    return result;
+    return extractWechatArticleHtml(result) || result;
   },
 };

--- a/src/cache/index.ts
+++ b/src/cache/index.ts
@@ -126,6 +126,7 @@ function parseCachedPayload(raw: string): CachedPayload | null {
   if (
     !parsed ||
     typeof parsed.content !== "string" ||
+    parsed.content.trim().length === 0 ||
     typeof parsed.method !== "string" ||
     typeof parsed.title !== "string"
   ) {
@@ -311,6 +312,8 @@ export async function setCache(
   engine?: string,
 ): Promise<void> {
   try {
+    if (!data.content.trim()) return;
+
     const key = await cacheKey(url, format, selector, engine);
     const effectiveTtl = ttl ?? getTtlForUrl(url);
 

--- a/src/handlers/convert.ts
+++ b/src/handlers/convert.ts
@@ -199,6 +199,7 @@ export function asFetchConvertError(error: unknown): ConvertError {
 export function isLikelyChallengeHtml(body: string): boolean {
   const lower = body.toLowerCase();
   return (
+    isWechatVerificationHtml(body) ||
     (lower.includes("passport.weibo") ||
       lower.includes("qrcode_login") ||
       lower.includes("login_type")) ||
@@ -210,6 +211,14 @@ export function isLikelyChallengeHtml(body: string): boolean {
     (lower.includes("just a moment") &&
       lower.includes("cloudflare") &&
       body.length < 10000)
+  );
+}
+
+export function isWechatVerificationHtml(body: string): boolean {
+  return (
+    body.includes("wappoc_appmsgcaptcha") ||
+    body.includes("当前环境异常") ||
+    body.includes("完成验证后即可继续访问")
   );
 }
 
@@ -499,7 +508,9 @@ async function tryFetchAndParse(
   }
 
   // 早期浏览器路径 — 对总是需要浏览器的站点跳过多余的静态获取
-  if (!finalHtml && alwaysNeedsBrowser(targetUrl) && browserAllowed) {
+  const requiresBrowser = alwaysNeedsBrowser(targetUrl);
+
+  if (!finalHtml && requiresBrowser && browserAllowed) {
     const result = await tryBrowserRendering(
       targetUrl, env, host, fallbacks, abortSignal, progress,
     );
@@ -508,7 +519,7 @@ async function tryFetchAndParse(
       method = "browser+readability+turndown";
       browserRendered = true;
     }
-  } else if (!finalHtml && alwaysNeedsBrowser(targetUrl) && !browserAllowed) {
+  } else if (!finalHtml && requiresBrowser && !browserAllowed) {
     // Anonymous 用户无 browser 权限 — 先走 Browser Use 远程浏览器，再降级住宅代理
     if (env.BROWSER_USE_API_KEY) {
       throwIfAborted(abortSignal);
@@ -528,6 +539,36 @@ async function tryFetchAndParse(
         finalHtml = proxyResult;
         method = "proxy+readability+turndown";
       }
+    }
+
+    // WeChat often serves usable article HTML to a MicroMessenger UA. Use this
+    // as a low-cost fallback for anonymous users before failing the request.
+    if (!finalHtml && targetUrl.includes("mp.weixin.qq.com")) {
+      const staticResult = await tryStaticFetch(
+        targetUrl, env, host, format, selector, forceBrowser, noCache, engine,
+        fallbacks, browserRendered, paywallDetected, sourceContentType,
+        resolvedUrl, method, progress, abortSignal, browserAllowed,
+      );
+      if (staticResult.earlyReturn) {
+        return staticResult.earlyReturn;
+      }
+      finalHtml = staticResult.finalHtml;
+      method = staticResult.method;
+      resolvedUrl = staticResult.resolvedUrl;
+      browserRendered = staticResult.browserRendered;
+      paywallDetected = staticResult.paywallDetected;
+      sourceContentType = staticResult.sourceContentType;
+      if (finalHtml) {
+        fallbacks.add("wechat_static_fallback");
+      }
+    }
+
+    if (!finalHtml) {
+      throw new ConvertError(
+        "Fetch Failed",
+        "This URL requires browser or proxy access, but no content was returned by the available fallback methods.",
+        502,
+      );
     }
   } else if (!finalHtml) {
     // 3. 静态获取
@@ -549,6 +590,21 @@ async function tryFetchAndParse(
 
   // 7. 去除 <script> 和 <style> 标签
   throwIfAborted(abortSignal);
+  if (!finalHtml.trim()) {
+    throw new ConvertError(
+      "Fetch Failed",
+      "The target URL returned no HTML content.",
+      502,
+    );
+  }
+  if (targetUrl.includes("mp.weixin.qq.com") && isWechatVerificationHtml(finalHtml)) {
+    throw new ConvertError(
+      "Fetch Failed",
+      "WeChat returned an environment verification page instead of the article content.",
+      502,
+    );
+  }
+
   finalHtml = finalHtml
     .replace(/<script\b[^>]*>[\s\S]*?<\/script>/gi, "")
     .replace(/<style\b[^>]*>[\s\S]*?<\/style>/gi, "");
@@ -678,6 +734,14 @@ async function tryFetchAndParse(
     } catch {
       // Jina 失败，使用现有内容继续
     }
+  }
+
+  if (!markdown.trim()) {
+    throw new ConvertError(
+      "No Content",
+      "The target page was fetched, but no readable content could be extracted.",
+      422,
+    );
   }
 
   switch (format) {
@@ -1125,6 +1189,14 @@ async function tryStaticFetch(
 
     const tokenCount = response.headers.get("x-markdown-tokens") || "";
     const isMarkdown = contentType.includes("text/markdown");
+    const isWechatVerification = isWechat && isWechatVerificationHtml(body);
+    if (isWechatVerification && !browserAllowed) {
+      throw new ConvertError(
+        "Fetch Failed",
+        "WeChat returned an environment verification page instead of the article content.",
+        502,
+      );
+    }
 
     // 6. 原生 markdown
     if (isMarkdown) {
@@ -1165,7 +1237,7 @@ async function tryStaticFetch(
 
     // 7. 检查是否需要浏览器渲染
     finalHtml = body;
-    if (browserAllowed && (forceBrowser || needsBrowserRendering(body, resolvedUrl))) {
+    if (browserAllowed && (forceBrowser || isWechatVerification || needsBrowserRendering(body, resolvedUrl))) {
       throwIfAborted(abortSignal);
       await progress("browser", "Rendering with browser");
       try {
@@ -1174,6 +1246,13 @@ async function tryStaticFetch(
         browserRendered = true;
         fallbacks.add(forceBrowser ? "browser_forced" : "browser_auto");
       } catch (e) {
+        if (isWechatVerification) {
+          throw new ConvertError(
+            "Fetch Failed",
+            "WeChat returned an environment verification page and browser rendering failed.",
+            502,
+          );
+        }
         console.error("Browser rendering failed, using static HTML:", e instanceof Error ? e.message : e);
       }
     }


### PR DESCRIPTION
## What changed

- Prevent empty conversion output from being cached or served from legacy cache entries.
- Add an anonymous WeChat static fallback using the MicroMessenger UA when browser/proxy fallbacks return no content.
- Detect WeChat environment verification pages and fail clearly instead of converting them.
- Update the WeChat adapter to extract `#js_content` into a focused article document with title, author, and lazy-loaded images.
- Add regression coverage for empty-cache handling and WeChat extraction behavior.

## Why

A WeChat article could render as an empty page because anonymous `alwaysBrowser` conversion continued with empty HTML after remote browser/proxy fallback failure, then cached the empty Markdown. Once cached, document navigation returned the empty result directly.

## Validation

- `npm run typecheck`
- `npm test` (47 files, 608 tests)
- `npm run build` dry run